### PR TITLE
feat: Do not ignore updates events as end user may want it

### DIFF
--- a/pkg/kube/watcher.go
+++ b/pkg/kube/watcher.go
@@ -63,7 +63,11 @@ func (e *EventWatcher) OnAdd(obj interface{}) {
 }
 
 func (e *EventWatcher) OnUpdate(oldObj, newObj interface{}) {
-	// Ignore updates
+	oldEvent := oldObj.(*corev1.Event)
+	newEvent := newObj.(*corev1.Event)
+	if newEvent.Count > oldEvent.Count {
+		e.onEvent(newEvent)
+	}
 }
 
 // Ignore events older than the maxEventAgeSeconds

--- a/pkg/kube/watcher_test.go
+++ b/pkg/kube/watcher_test.go
@@ -270,6 +270,33 @@ func TestOnEvent_WithObjectMetadata(t *testing.T) {
 	}, event.InvolvedObject.OwnerReferences)
 }
 
+func TestOnUpdate_WhenCountIncreases(t *testing.T) {
+	metricsStore := metrics.NewMetricsStore("test_")
+	defer metrics.DestroyMetricsStore(metricsStore)
+	ew := newMockEventWatcher(300, metricsStore)
+
+	processed := 0
+	ew.fn = func(e *EnhancedEvent) { processed++ }
+
+	startup := time.Now().Add(-10 * time.Minute)
+	ew.setStartUpTime(startup)
+
+	base := corev1.Event{
+		ObjectMeta:    metav1.ObjectMeta{Name: "event1"},
+		LastTimestamp: metav1.Time{Time: time.Now()},
+		InvolvedObject: corev1.ObjectReference{UID: "test", Name: "test-1"},
+		Count:         1,
+	}
+	updated := base
+	updated.Count = 2
+
+	ew.OnUpdate(&base, &updated)
+	assert.Equal(t, 1, processed, "count increase should trigger onEvent")
+
+	ew.OnUpdate(&updated, &updated)
+	assert.Equal(t, 1, processed, "same count (informer resync) should not trigger onEvent")
+}
+
 func TestOnEvent_DeletedObjects(t *testing.T) {
 	metricsStore := metrics.NewMetricsStore("test_")
 	defer metrics.DestroyMetricsStore(metricsStore)


### PR DESCRIPTION
We may want events `OnUpdate` as the final user may want this information, I think that we should send it and let final user decide what to do on it.